### PR TITLE
Remove unnecessary component scan annotations

### DIFF
--- a/src/main/java/com/fluffy/kittens/KittensApplication.java
+++ b/src/main/java/com/fluffy/kittens/KittensApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@ComponentScan
 @SpringBootApplication
 public class KittensApplication {
 


### PR DESCRIPTION
`@ComponentScan` annotations are not necessary on `@SpringBootApplication` classes as they are inherited